### PR TITLE
Fix: non deterministic graph

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -25,6 +26,7 @@ type Options struct {
 	Module  string
 	CommitA string
 	CommitB string
+	Discard bool
 
 	// Grouping options
 	GroupByPkgPrefix string
@@ -48,6 +50,7 @@ func RootCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&opts.Format, "format", "f", "json", "e.g text/json/json-minified")
 	cmd.PersistentFlags().StringVarP(&opts.CommitA, "a", "a", "origin/master", "Commit A")
 	cmd.PersistentFlags().StringVarP(&opts.CommitB, "b", "b", "HEAD", "Commit B")
+	cmd.PersistentFlags().BoolVarP(&opts.Discard, "discard", "d", false, "Discard output")
 
 	cmd.AddCommand(GroupCmd(opts))
 
@@ -130,6 +133,10 @@ func GroupFunc(opts *Options) affected.GroupFunc {
 // Writer returns a writer based on the options, defaults to stdout
 func Writer(opts *Options) io.Writer {
 	var w io.Writer = os.Stdout
+
+	if opts.Discard {
+		w = ioutil.Discard
+	}
 
 	// Add suoport for writing directly to file with -v output for also writing to stdout
 	// at the same time via a T writer


### PR DESCRIPTION
### Problem

The package graph relations were built in a non-deterministic way due to using a map as the initial node storage. This results in false positives and negatives when attempting to determine what packages have been affected by others, directly or indirectly.

### Solution

Refactors Graph creation to build an initial slice of Package's to build the relations. Then add that to the graph map.

### Bonus

Added a `-d/--discard` flag to discard the output.