### PR TITLE
fix(glob): out of bounds panic when removing excludes from slice

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.12
 require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
+	github.com/stretchr/testify v1.2.2
 	golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -12,6 +13,7 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -22,6 +24,7 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/glob/glob.go
+++ b/pkg/glob/glob.go
@@ -21,6 +21,9 @@ const (
 // IncludeDefault returns the default set of default include globs
 func IncludeDefault() []string {
 	return []string{
+		"**/*.go",
+		"**/go.mod",
+		"**/go.sum",
 		"/**/*.go",
 		"/**/go.mod",
 		"/**/go.sum",
@@ -30,6 +33,7 @@ func IncludeDefault() []string {
 // ExcludeDefault returns the default set of default exlude globs
 func ExcludeDefault() []string {
 	return []string{
+		"**/*_test.go",
 		"/**/*_test.go",
 	}
 }
@@ -65,7 +69,10 @@ func Exclude(in []string, globs ...string) []string {
 	for _, x := range Include(in, globs...) {
 		for i, v := range in {
 			if v == x {
-				in = append(in[:i], in[i+2:]...)
+				copy(in[i:], in[i+1:])
+				in[len(in)-1] = ""
+				in = in[:len(in)-1]
+
 				break
 			}
 		}

--- a/pkg/glob/glob_test.go
+++ b/pkg/glob/glob_test.go
@@ -1,0 +1,111 @@
+package glob
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInclude(t *testing.T) {
+	testCases := map[string]struct {
+		files    []string
+		globs    []string
+		expected []string
+	}{
+		"ReturnsDefaultIncludeGlobsRelativePaths": {
+			files: []string{
+				"go.mod",
+				"go.sum",
+				"foo.go",
+				"foo_test.go",
+				"bar/bar.go",
+				"bar/bar_test.go",
+				"README.md",
+			},
+			globs: IncludeDefault(),
+			expected: []string{
+				"go.mod",
+				"go.sum",
+				"foo.go",
+				"foo_test.go",
+				"bar/bar.go",
+				"bar/bar_test.go",
+			},
+		},
+		"ReturnsDefaultIncludeGlobsAbsolutePaths": {
+			files: []string{
+				"/root/go.mod",
+				"/root/go.sum",
+				"/root/foo.go",
+				"/root/foo_test.go",
+				"/root/bar/bar.go",
+				"/root/bar/bar_test.go",
+				"/root/README.md",
+			},
+			globs: IncludeDefault(),
+			expected: []string{
+				"/root/go.mod",
+				"/root/go.sum",
+				"/root/foo.go",
+				"/root/foo_test.go",
+				"/root/bar/bar.go",
+				"/root/bar/bar_test.go",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		tc := testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, Include(tc.files, tc.globs...))
+		})
+	}
+}
+
+func TestExclude(t *testing.T) {
+	testCases := map[string]struct {
+		files    []string
+		globs    []string
+		expected []string
+	}{
+		"RemovesDefaultExcludedGlobsRelativePaths": {
+			files: []string{
+				"foo.go",
+				"foo_test.go",
+				"bar/bar.go",
+				"bar/bar_test.go",
+			},
+			globs: ExcludeDefault(),
+			expected: []string{
+				"foo.go",
+				"bar/bar.go",
+			},
+		},
+		"RemovesDefaultExcludedGlobsAbsolutePaths": {
+			files: []string{
+				"/root/foo.go",
+				"/root/foo_test.go",
+				"/root/bar/bar.go",
+				"/root/bar/bar_test.go",
+			},
+			globs: ExcludeDefault(),
+			expected: []string{
+				"/root/foo.go",
+				"/root/bar/bar.go",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		tc := testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, Exclude(tc.files, tc.globs...))
+		})
+	}
+}


### PR DESCRIPTION
### Problem

A panic could occur when removing the last element from a given slice when using exclude globs.

### Solution

* Added test case to exclude a last element from a slice to replicate the issue
* Updated the code to remove an element from a slice to a slower but safer solution