### PR TITLE
17078: Fix packages appeneded to modified

### DIFF
--- a/pkg/affected/packages.go
+++ b/pkg/affected/packages.go
@@ -154,7 +154,7 @@ func Packages(name, a, b string, opts ...PackagesOption) ([]Package, error) {
 			pkgs = append(pkgs, updated...)
 
 			// Add packages to modified packages
-			modified = append(modified, pkgs...)
+			modified = append(modified, updated...)
 		case strings.HasSuffix(file, ".go"):
 			dir := filepath.Dir(file)
 


### PR DESCRIPTION
Packages should not be appended to the modified, only updated.
