### PR TITLE
Ignore indirect module deps

### DIFF
--- a/pkg/affected/packages.go
+++ b/pkg/affected/packages.go
@@ -241,10 +241,18 @@ func diffModfile(r vcs.FileAtRefReader, l module.PackageLoader, refA, refB, path
 	require := make(map[string]string)
 
 	for _, module := range modfileA.Require {
+		if module.Indirect {
+			continue
+		}
+
 		require[module.Mod.Path] = module.Mod.Version
 	}
 
 	for _, module := range modfileB.Require {
+		if module.Indirect {
+			continue
+		}
+
 		v, ok := require[module.Mod.Path]
 		if !ok { // new module
 			continue


### PR DESCRIPTION
### Problem

Currently we load *all* module deps when checking for changes in the mod file, this causes some issues where we start trying to load packages that `go list` doesn't seem to be able to handle - causing an empty list to be passed back from `packages.Load`. (The offending package is `github.com/google/go-cmp` which we don't have a direct or indirect dep in the mod file and running `go mod tidy` doesn't resolve or add it either).

### Solution

We actually only care about checking services / packages that are importing direct dependencies as the indirect deps as their name alludes to are indirect and imported by one of the direct deps and wouldn't be imported anywhere in the repo in question.